### PR TITLE
Free disk space

### DIFF
--- a/.github/workflows/build-flux-func-13b-gpu.yaml
+++ b/.github/workflows/build-flux-func-13b-gpu.yaml
@@ -37,6 +37,10 @@ jobs:
         #
         # TODO scan the GPU base image
         # ${{ steps.grype.outputs.cmd }} docker:ghcr.io/open-flux-ai/serve/llama-cpp-python:${IMAGE}-gpu
+    - name: Free disk space
+      shell: bash
+      run: |
+        ./scripts/free_disk_space.sh
     - name: Build Flux Func 13B GPU
       id: build-flux-func-13b
       run: |

--- a/scripts/free_disk_space.sh
+++ b/scripts/free_disk_space.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Following: 
+# https://github.com/kingdonb/stats-tracker-ghcr/pull/49
+# https://github.com/kingdonb/stats-tracker-ghcr/commit/8af93bea0c6bc41e3ea831a1f2703fcad5301e53
+# (and) https://github.com/orgs/community/discussions/25678
+# with the omission of ghc-8 and hhvm, (that no longer seem to be installed by default)
+
+echo "=============================================================================="
+echo "Freeing up disk space on CI system"
+echo "=============================================================================="
+echo "Listing 100 largest packages"
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+df -h
+echo "Removing large packages"
+# sudo apt-get remove -y '^ghc-8.*'
+sudo apt-get remove -y '^dotnet-.*'
+sudo apt-get remove -y '^llvm-.*'
+sudo apt-get remove -y 'php.*'
+sudo apt-get remove -y azure-cli google-cloud-cli google-chrome-stable firefox powershell mono-devel
+sudo apt-get autoremove -y
+sudo apt-get clean
+df -h
+echo "Removing large directories"
+# deleting 15GB
+rm -rf /usr/share/dotnet/
+df -h


### PR DESCRIPTION
Separate out the script and commit which triggers the 13b-gpu build into two commits

(in case we want to cherry-pick - note that each workflow is triggered by `main` branch and `path`)